### PR TITLE
Fixed unit shaking and Add anti-overlap feature

### DIFF
--- a/js/rts-2d.js
+++ b/js/rts-2d.js
@@ -879,7 +879,7 @@ function logic(){
 					}else{
 						if(distance(p0_units[loop_counter],
 									p0_units[it]) <= 20){
-							random_walk(p0_units[loop_counter], 40);
+							keep_distance(p0_units[loop_counter], p0_units[it]);
 						}
 					}
 				}
@@ -1091,11 +1091,15 @@ function distance(u1, u2) {
 					 Math.pow(u1[1] - u2[1], 2));
 }
 
-// let unit to walk a little bit
-function random_walk(unit) {
-	unit[3] = unit[0] + Math.random() * 30 - 15; 
-	unit[4] = unit[1] + Math.random() * 30 - 15;
+function keep_distance(u1, u2) {
+    var rand1 = Math.random();
+    var rand2 = Math.random();
+	// 2 * rand1 and 2* rand2 is to seperate units that have exactly the same (x,y)
+	// you can try using one random number instead of two, it's hard to describe
+    u1[3] = Math.round(u1[3] - 1.0 * rand2 * (u2[0] - u1[0] + 2 * rand1));
+    u1[4] = Math.round(u1[4] - 1.0 * rand1 * (u2[1] - u1[1] + 2 * rand2));
 }
+
 
 function play_audio(id){
     if(settings['audio-volume'] <= 0){

--- a/js/rts-2d.js
+++ b/js/rts-2d.js
@@ -868,6 +868,21 @@ function logic(){
                     }while(fog_counter--);
                 }
             }else{
+				// When reached destination 
+				// units should not too close to each other
+
+				//mark unit is not moving
+				p0_units[loop_counter][7] = false;
+				for(var it = 0; it< p0_units.length; it += 1){
+					if(it == loop_counter){
+
+					}else{
+						if(distance(p0_units[loop_counter],
+									p0_units[it]) <= 20){
+							random_walk(p0_units[loop_counter], 40);
+						}
+					}
+				}
 			}
 
             // If reloading, decrease reload,...
@@ -1068,6 +1083,18 @@ function m(x0, y0, x1, y1){
 
 function in_position(x0, y0, x1, y1) {
 	return Math.abs(x0 - x1) <= 1 && Math.abs(y0 - y1) <= 1 ? false : true;
+}
+
+// get the distance from u1 to u2
+function distance(u1, u2) {
+	return Math.sqrt(Math.pow(u1[0] - u2[0], 2) +
+					 Math.pow(u1[1] - u2[1], 2));
+}
+
+// let unit to walk a little bit
+function random_walk(unit) {
+	unit[3] = unit[0] + Math.random() * 30 - 15; 
+	unit[4] = unit[1] + Math.random() * 30 - 15;
 }
 
 function play_audio(id){

--- a/js/rts-2d.js
+++ b/js/rts-2d.js
@@ -827,8 +827,10 @@ function logic(){
     if(loop_counter >= 0){
         do{
             // If not yet reached destination, move and update fog.
-            if(p0_units[loop_counter][0] != p0_units[loop_counter][3]
-              || p0_units[loop_counter][1] != p0_units[loop_counter][4]){
+			if(in_position(p0_units[loop_counter][0],
+						   p0_units[loop_counter][1],
+						   p0_units[loop_counter][3],
+						   p0_units[loop_counter][4])){
                 var j = m(
                   p0_units[loop_counter][0],
                   p0_units[loop_counter][1],
@@ -865,7 +867,8 @@ function logic(){
                         }
                     }while(fog_counter--);
                 }
-            }
+            }else{
+			}
 
             // If reloading, decrease reload,...
             if(p0_units[loop_counter][5] > 0){
@@ -1061,6 +1064,10 @@ function m(x0, y0, x1, y1){
     }else{
         return j1 > j0 ? [j0 / j1, 1] : [.5, .5];
     }
+}
+
+function in_position(x0, y0, x1, y1) {
+	return Math.abs(x0 - x1) <= 1 && Math.abs(y0 - y1) <= 1 ? false : true;
 }
 
 function play_audio(id){

--- a/js/rts-2d.js
+++ b/js/rts-2d.js
@@ -1081,21 +1081,21 @@ function m(x0, y0, x1, y1){
     }
 }
 
-function in_position(x0, y0, x1, y1) {
-	return Math.abs(x0 - x1) <= 1 && Math.abs(y0 - y1) <= 1 ? false : true;
+function in_position(x0, y0, x1, y1){
+    return Math.abs(x0 - x1) <= 1 && Math.abs(y0 - y1) <= 1 ? false : true;
 }
 
 // get the distance from u1 to u2
-function distance(u1, u2) {
-	return Math.sqrt(Math.pow(u1[0] - u2[0], 2) +
-					 Math.pow(u1[1] - u2[1], 2));
+function distance(u1, u2){
+    return Math.sqrt(Math.pow(u1[0] - u2[0], 2) +
+		     Math.pow(u1[1] - u2[1], 2));
 }
 
-function keep_distance(u1, u2) {
+function keep_distance(u1, u2){
     var rand1 = Math.random();
     var rand2 = Math.random();
-	// 2 * rand1 and 2* rand2 is to seperate units that have exactly the same (x,y)
-	// you can try using one random number instead of two, it's hard to describe
+    // 2 * rand1 and 2* rand2 is to seperate units that have exactly the same (x,y)
+    // you can try using one random number instead of two, it's hard to describe
     u1[3] = Math.round(u1[3] - 1.0 * rand2 * (u2[0] - u1[0] + 2 * rand1));
     u1[4] = Math.round(u1[4] - 1.0 * rand1 * (u2[1] - u1[1] + 2 * rand2));
 }


### PR DESCRIPTION
Shaking: Units will "shaking" when not moving, for __(unit[0], unit[1])__ are float but the condition in Line 830 is only for int.

Overlap: Units may overlap each other and become united when having a same destination. Added a check when unit is not moving and force unit to random walk a little bit when unit are too close to other unit. It's rough yet just works, I'll impove it later. (but it is fun that I can make a unit by combining a lot of unit)